### PR TITLE
feat(styleguide): add support for APP_ROOT environment variable

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm ci
 
       - name: Build styleguide
-        run: npm run build:styleguide
+        run: APP_ROOT=/Eccube-Styleguide npm run build:styleguide
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/README.md
+++ b/README.md
@@ -96,3 +96,20 @@ $ npm run dev
 ```
 $ npm run build:moc
 ```
+
+## 環境変数による設定
+
+### appRoot の設定
+
+スタイルガイドをビルドする際、JavaScriptやCSSなどのリソースのパスに接頭辞を付けたい場合は、環境変数 `APP_ROOT` を使用できます。
+これは特にサブディレクトリにデプロイする場合に便利です。
+
+例えば、`/styleguide/` というパスにデプロイする場合：
+
+```
+$ APP_ROOT=/styleguide/ npm run build:styleguide:generate
+```
+
+`APP_ROOT` が指定されない場合、デフォルト値は空文字 (`''`) となります。
+
+GitHub Actions でのデプロイ時にも `APP_ROOT=/Eccube-Styleguide` が設定されており、GitHub Pages 上では適切なパスでリソースが読み込まれます。

--- a/assets/gulp/styleguide.js
+++ b/assets/gulp/styleguide.js
@@ -4,6 +4,9 @@ var gulp = require('gulp');
 var styleguide = require('nanasess-sc5-styleguide');
 var outputPath = 'public';
 
+// appRoot の環境変数を取得、指定がなければデフォルトで空文字を設定
+var appRoot = process.env.APP_ROOT || '';
+
 const {src,dest,scss_option} = global;
 
 const target = src+'assets/scss/**/*.scss';
@@ -12,6 +15,7 @@ const styelguideConfig = {
     title: 'My Styleguide',
     rootPath: outputPath,
     overviewPath: './assets/styleguide.md',
+    appRoot: appRoot, // appRoot の設定を追加
     extraHead: [
         '<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">',
         '<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">',


### PR DESCRIPTION
Add `APP_ROOT` environment variable to configure resource paths during styleguide build. Updated GitHub Actions workflow and documentation to reflect this change.